### PR TITLE
Fix `read_payload` test function

### DIFF
--- a/1. Message Structure/Lesson.ipynb
+++ b/1. Message Structure/Lesson.ipynb
@@ -667,7 +667,7 @@
     "    assert stream.read(1) == b\"x\"\n",
     "    print(\"Test passed\")\n",
     "    \n",
-    "test_read_checksum()"
+    "test_read_payload()"
    ]
   },
   {


### PR DESCRIPTION
The test here should be for `read_payload` not `read_checksum` (which was the previous test)